### PR TITLE
Approve

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ xlsxwriter
 matplotlib
 plotly
 streamlit_option_menu
+xlrd


### PR DESCRIPTION
Add xlrd to support .xls file uploads

This commit adds the `xlrd` library to `requirements.txt`. The `xlrd` library is required by pandas to read older Excel (.xls) files. This change enables your application to correctly process uploads of .xls files in addition to .xlsx files.