### PR TITLE
Fix: Explicitly set engine for pd.read_excel based on file extension

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import streamlit as st
+import os
 import pandas as pd
 import numpy as np
 import re
@@ -129,7 +130,23 @@ if 'selected_case_ids' not in st.session_state:
 # Function to load and process data
 @st.cache_data
 def load_data(file):
-    return pd.read_excel(file)
+    if file is None:
+        return None
+    
+    try:
+        file_name = file.name
+        file_extension = os.path.splitext(file_name)[1].lower()
+        
+        if file_extension == '.xls':
+            return pd.read_excel(file, engine='xlrd')
+        elif file_extension == '.xlsx':
+            return pd.read_excel(file, engine='openpyxl')
+        else:
+            raise ValueError("Unsupported file type. Please upload .xls or .xlsx files.")
+            
+    except Exception as e:
+        st.error(f"Error loading file: {e}")
+        return None
 
 # Function to process main dataframe
 def process_main_df(df):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ xlsxwriter
 matplotlib
 plotly
 streamlit_option_menu
+xlrd


### PR DESCRIPTION
Addresses a ValueError when uploading .xls files where pandas could not automatically determine the Excel file format.

The `load_data` function in `app.py` has been updated to:
- Check the file extension of the uploaded file.
- Use `engine='xlrd'` for `.xls` files.
- Use `engine='openpyxl'` for `.xlsx` files.
- Raise a ValueError for unsupported file types.

This ensures the correct pandas engine is used, resolving the previously reported issue. `xlrd` was already added to requirements.txt in a prior step.