### PR TITLE
Fix: Remove unsupported theme argument for older Streamlit version

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,8 +16,7 @@ st.set_page_config(
     page_title="Intellipen SmartQ",
     page_icon="📊",
     layout="wide",
-    initial_sidebar_state="expanded",
-    theme="auto"  # Respect OS/browser preference for light/dark mode
+    initial_sidebar_state="expanded"
 )
 
 # Custom CSS for styling


### PR DESCRIPTION
- Removed `theme='auto'` from `st.set_page_config()` as it caused a TypeError due to being an unsupported argument in the current Streamlit environment.
- Dark mode styling will rely solely on the CSS media query `@media (prefers-color-scheme: dark)`.

This commit amends the previous attempt to implement dark mode styling.