### PR TITLE
Fix: Correct IndentationError in Closed SRs table display logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -2105,48 +2105,51 @@ else:
 
                     st.markdown(f"**Total Displayed Closed SRs (filtered by closure date):** {len(filtered_closed_srs_df)}")
 
-                    if not filtered_closed_srs_df.empty:
-                    all_closed_columns = filtered_closed_srs_df.columns.tolist()
-                    # Remove internal helper columns from user selection options
-                    # 'Closure-Year-Week' is the one specifically created for this table's filtering.
-                    # 'Year-Week' might exist if it was in the original sr_overview_df from created_on processing.
-                    internal_cols_to_remove = ['Closure-Year-Week', 'Year-Week']
-                    for col_to_remove in internal_cols_to_remove:
-                        if col_to_remove in all_closed_columns:
-                            all_closed_columns.remove(col_to_remove)
+                    if not filtered_closed_srs_df.empty: # This is line 2108 approx.
+                        all_closed_columns = filtered_closed_srs_df.columns.tolist() # Line 2109 - Start of block to indent
+                        # Remove internal helper columns from user selection options
+                        # 'Closure-Year-Week' is the one specifically created for this table's filtering.
+                        # 'Year-Week' might exist if it was in the original sr_overview_df from created_on processing.
+                        internal_cols_to_remove = ['Closure-Year-Week', 'Year-Week']
+                        for col_to_remove in internal_cols_to_remove:
+                            if col_to_remove in all_closed_columns:
+                                all_closed_columns.remove(col_to_remove)
 
-                    default_closed_cols = ['Service Request', 'Status', 'Created On', 'LastModDateTime', 'Resolution'] # Example, adjust as needed
-                    sanitized_default_closed_cols = [col for col in default_closed_cols if col in all_closed_columns]
+                        default_closed_cols = ['Service Request', 'Status', 'Created On', 'LastModDateTime', 'Resolution'] # Example, adjust as needed
+                        sanitized_default_closed_cols = [col for col in default_closed_cols if col in all_closed_columns]
 
-                    if 'closed_sr_data_cols_multiselect' not in st.session_state:
-                        st.session_state.closed_sr_data_cols_multiselect = sanitized_default_closed_cols
+                        if 'closed_sr_data_cols_multiselect' not in st.session_state:
+                            st.session_state.closed_sr_data_cols_multiselect = sanitized_default_closed_cols
 
-                    selected_closed_columns = st.multiselect(
-                        "Select columns to display for Closed SRs:",
-                        options=all_closed_columns,
-                        default=st.session_state.closed_sr_data_cols_multiselect,
-                        key="multiselect_closed_sr_data"
-                    )
-                    st.session_state.closed_sr_data_cols_multiselect = selected_closed_columns
+                        selected_closed_columns = st.multiselect(
+                            "Select columns to display for Closed SRs:",
+                            options=all_closed_columns,
+                            default=st.session_state.closed_sr_data_cols_multiselect,
+                            key="multiselect_closed_sr_data"
+                        )
+                        st.session_state.closed_sr_data_cols_multiselect = selected_closed_columns
 
-                    if selected_closed_columns:
-                        st.dataframe(filtered_closed_srs_df[selected_closed_columns], hide_index=True)
+                        if selected_closed_columns:
+                            st.dataframe(filtered_closed_srs_df[selected_closed_columns], hide_index=True)
+                        else:
+                            # Show all available (minus internal Year-Week) if no columns selected but data exists
+                            # Ensure we use the correct list of all_closed_columns (which has helpers removed)
+                            st.dataframe(filtered_closed_srs_df[all_closed_columns] if all_closed_columns else filtered_closed_srs_df, hide_index=True)
+
+                        # Download button for Closed SRs
+                        # Ensure download uses the correct set of columns (selected or all available for display)
+                        cols_for_download = selected_closed_columns if selected_closed_columns else all_closed_columns
+                        excel_closed_sr_data = generate_excel_download(filtered_closed_srs_df[cols_for_download] if cols_for_download else filtered_closed_srs_df)
+                        st.download_button(
+                            label="📥 Download Closed SRs Data",
+                            data=excel_closed_sr_data,
+                            file_name=f"closed_srs_data_{datetime.now().strftime('%Y%m%d_%H%M%S')}.xlsx",
+                            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                            key="download_closed_srs"
+                        )
+                    # This else corresponds to 'if not filtered_closed_srs_df.empty:'
                     else:
-                        # Show all available (minus internal Year-Week) if no columns selected but data exists
-                        st.dataframe(filtered_closed_srs_df[[col for col in all_closed_columns if col != 'Year-Week']] if 'Year-Week' in all_closed_columns else filtered_closed_srs_df, hide_index=True)
-
-                    # Download button for Closed SRs
-                    excel_closed_sr_data = generate_excel_download(filtered_closed_srs_df[selected_closed_columns if selected_closed_columns else all_closed_columns])
-                    st.download_button(
-                        label="📥 Download Closed SRs Data",
-                        data=excel_closed_sr_data,
-                        file_name=f"closed_srs_data_{datetime.now().strftime('%Y%m%d_%H%M%S')}.xlsx",
-                        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                        key="download_closed_srs"
-                    )
-
-                else:
-                    st.info("No Closed SR data to display based on current filters.")
+                        st.info("No Closed SR data to display based on current filters.")
 
 
 st.markdown("---")


### PR DESCRIPTION
- Fixed an IndentationError affecting the display of the Closed SRs table when data is present.
- Ensured the block responsible for column selection, table rendering, and download button is correctly indented under the `if not filtered_closed_srs_df.empty:` condition.

Refactor: Align Closed SRs table with bar chart using LastModDateTime

- Revised the 'Closed SRs' table in the 'SR Overview' tab to filter by 'LastModDateTime' instead of 'Created On'. This aligns the table data with the 'Service Requests Closed Per Week' bar chart.
- The helper column 'Closure-Year-Week' is now derived from 'LastModDateTime'.
- Week filter options for this table are now generated based on unique 'Closure-Year-Week' values from the set of closed SRs.
- Filter labels updated to 'Closure Week Period' and 'Specific Closure Day'.
- Added an explicit import for `_get_week_display_str` from `utils.py` as it's now used directly in `app.py`.
- Ensured essential columns ('Status', 'LastModDateTime') are checked before rendering the table.
- Confirmed that internal helper columns ('Closure-Year-Week', 'Year-Week') are correctly excluded from user-selectable columns.

Fix: Correct IndentationError in Closed SRs table logic

- Fixed an IndentationError that occurred after adding checks for 'Status' and 'Created On' columns.
- Ensured the block for processing 'Created On' and creating 'Year-Week' for the closed SRs data is correctly indented.

Feat: Add Closed SRs table to SR Overview tab

- Added a new table to the 'SR Overview' tab to display closed SRs.
- Closed SRs are defined by statuses: ["closed", "completed", "cancelled", "approval rejected", "rejected by ps"].
- The table is located below the 'Filterable SR Data' table.
- Implemented independent Week Period and Specific Day (Created On) filters for the Closed SRs table.
- Added a multiselect widget for users to choose columns to display in the Closed SRs table, with selection persisted in session state.
- Included a download button for the Closed SRs data.
- Added checks to ensure 'Status' and 'Created On' columns exist in the uploaded SR data before rendering the table, displaying a warning if not.
- Improved consistency by using session state for column selection in the existing 'Filterable SR Data' table as well.