### PR TITLE
Fix: Correct SR approval breakdown display and formatting

### DIFF
--- a/app.py
+++ b/app.py
@@ -977,7 +977,7 @@ else:
                         # Use case-insensitive and whitespace-agnostic comparison
                         if str(row['Status']).strip().lower() == 'waiting for approval':
                             # Get the breakdown for this status
-                            srs_waiting = df_srs_status_valid[df_srs_status_valid['Status'].astype(str).str.strip().lower() == 'waiting for approval']
+                            srs_waiting = df_srs_status_valid[df_srs_status_valid['Status'].apply(lambda x: str(x).strip().lower() == 'waiting for approval')]
 
                             if not srs_waiting.empty and 'Pending With' in srs_waiting.columns:
                                 # Breakdown for cases


### PR DESCRIPTION
This commit addresses two issues with the SR status summary:
1. The breakdown for "Waiting for approval" was not showing if the status text had different casing or whitespace. The status matching is now case-insensitive and ignores leading/trailing whitespace.
2. The SR status summary table formatting did not match other tables. The display has been reverted to use `st.dataframe` with the appropriate styling, and indentation is now done with Unicode characters to ensure correct rendering.

This commit also fixes a typo in a variable name within the breakdown logic that was causing an error, and resolves an `AttributeError` by using a more robust `.apply()` method for filtering.

A test case has been added to verify the case-insensitive status matching.