### PR TITLE
Fix: Revert font styling to default

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,9 +93,6 @@ def set_custom_theme():
         min-width: 50px !important;
         max-width: 50px !important;
     }
-    .st-ch {
-        font-size: 14px;
-    }
     .action-button {
         background-color: #1976d2;
         color: white;


### PR DESCRIPTION
This commit removes a custom CSS rule that was unintentionally affecting the font size of table headers throughout the application. This change reverts the table fonts to the default Streamlit theme.